### PR TITLE
Fix: Detected blocking call to load_default_certs with args

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
           - --branch=master
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.9.3
+    rev: v0.9.7
     hooks:
       - id: ruff
         args:
@@ -53,14 +53,14 @@ repos:
         files: ^((custom_components/openmotics)/.+)?[^/]+\.py$
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.31.0
+    rev: 0.31.2
     hooks:
       - id: check-github-workflows
       - id: check-github-actions
       - id: check-readthedocs
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.0
+    rev: v2.4.1
     hooks:
       - id: codespell
         args:
@@ -71,7 +71,7 @@ repos:
         exclude: ^tests/
 
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.8.2
+    rev: 1.8.3
     hooks:
       - id: bandit
         args:
@@ -117,7 +117,7 @@ repos:
         args: []
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.14.1
+    rev: v1.15.0
     hooks:
       - id: mypy
         exclude: ^docs/|^tests
@@ -126,7 +126,7 @@ repos:
           # - pyhaopenmotics>=0.0.7
 
   - repo: https://github.com/PyCQA/pylint.git
-    rev: v3.3.3
+    rev: v3.3.4
     hooks:
       - id: pylint
         args: ["--exit-zero"]

--- a/custom_components/openmotics/config_flow.py
+++ b/custom_components/openmotics/config_flow.py
@@ -32,6 +32,7 @@ from homeassistant.const import (
 # from homeassistant.helpers.config_entry_oauth2_flow import AbstractOAuth2FlowHandler
 from homeassistant.helpers import config_entry_oauth2_flow, config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.util.ssl import get_default_context, get_default_no_verify_context
 
 from .const import CONF_INSTALLATION_ID, DOMAIN, ENV_CLOUD, ENV_LOCAL
 from .exceptions import CannotConnect
@@ -269,13 +270,18 @@ class OpenMoticsFlowHandler(
                 CONF_VERIFY_SSL: user_input[CONF_VERIFY_SSL],
             }
             version = None
+            ssl_context = get_default_context()
+            if not self.data[CONF_VERIFY_SSL]:
+                ssl_context = get_default_no_verify_context()
+
             try:
                 omclient = LocalGateway(
                     localgw=self.data[CONF_IP_ADDRESS],
                     username=self.data[CONF_NAME],
                     password=self.data[CONF_PASSWORD],
                     port=self.data[CONF_PORT],
-                    tls=self.data[CONF_VERIFY_SSL],
+                    # tls=self.data[CONF_VERIFY_SSL],
+                    ssl_context=ssl_context,
                 )
                 await omclient.get_token()
 

--- a/custom_components/openmotics/coordinator.py
+++ b/custom_components/openmotics/coordinator.py
@@ -9,7 +9,6 @@ from pyhaopenmotics import (
     LocalGateway,
     OpenMoticsCloud,
     OpenMoticsError,
-    get_ssl_context,
 )
 
 from homeassistant.const import (
@@ -21,6 +20,7 @@ from homeassistant.const import (
 )
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.util.ssl import get_default_context, get_default_no_verify_context
 
 from .const import CONF_INSTALLATION_ID, DEFAULT_SCAN_INTERVAL, DOMAIN
 
@@ -134,9 +134,9 @@ class OpenMoticsLocalDataUpdateCoordinator(OpenMoticsDataUpdateCoordinator):
             name=name,
         )
         self._install_id = self.config_entry.data.get(CONF_IP_ADDRESS)  # type: ignore
-        ssl_context = get_ssl_context(
-            verify_ssl=self.config_entry.data.get(CONF_VERIFY_SSL) # type: ignore
-        )
+        ssl_context = get_default_context()
+        if not self.config_entry.data.get(CONF_VERIFY_SSL):
+            ssl_context = get_default_no_verify_context()
 
         """Set up a OpenMotics controller"""
         self._omclient = LocalGateway(


### PR DESCRIPTION
Detected blocking call to load_default_certs with args (<ssl.SSLContext object at 0xffff83b08ef0>, <Purpose.SERVER_AUTH: _ASN1Object(nid=129, shortname='serverAuth', longname='TLS Web Server Authentication', oid='1.3.6.1.5.5.7.3.1')>) inside the event loop by custom integration 'openmotics' at custom_components/openmotics/coordinator.py, line 137: ssl_context = get_ssl_context